### PR TITLE
Fix OAuth configuration and documentation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,10 @@
+# Copy this file to .env and set values for your environment
+GOOGLE_CLIENT_ID=
+GOOGLE_CLIENT_SECRET=
+GOOGLE_ACCESS_TOKEN=
+GOOGLE_REFRESH_TOKEN=
+SESSION_SECRET=remarkable-planner-secret-key-2025
+DATABASE_URL=
+BASE_URL=
+REPLIT_DEV_DOMAIN=
+REPLIT_DOMAINS=

--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,5 @@ dist
 .DS_Store
 server/public
 vite.config.ts.*
-*.tar.gz
+*.tar.gz.env
+.env

--- a/README.md
+++ b/README.md
@@ -1,1 +1,27 @@
-# howremarkable
+# Howremarkable Calendar Application
+
+This project provides a calendar and note management system. OAuth authentication with Google allows syncing events.
+
+## Setup
+
+1. Copy `.env.example` to `.env` and fill in the required values.
+2. Ensure your Google Cloud OAuth credentials match the `BASE_URL` used by the server.
+3. Run `npm install` and then `npm start` to launch the application.
+
+## OAuth configuration
+
+The server expects the following environment variables:
+- `GOOGLE_CLIENT_ID`
+- `GOOGLE_CLIENT_SECRET`
+- `GOOGLE_ACCESS_TOKEN` *(optional for initial tokens)*
+- `GOOGLE_REFRESH_TOKEN` *(optional for initial tokens)*
+- `SESSION_SECRET`
+- `DATABASE_URL`
+- `BASE_URL` *(e.g. `https://your-app.example.com`)*
+
+When running in Replit, `BASE_URL` may be automatically derived from `REPLIT_DEV_DOMAIN` or `REPLIT_DOMAINS`.
+
+## Development
+
+Use `npm run dev` to run the server with Vite in development mode. Production
+builds run from `dist/`.

--- a/server/auth-fix.ts
+++ b/server/auth-fix.ts
@@ -65,40 +65,10 @@ export function setupAuthenticationFix(app: Express): void {
   app.use('/api/simplepractice', requireAuth);
   app.use('/api/upload', requireAuth);
 
-  // 4. Enhanced OAuth success handler
-  app.get('/api/auth/google/callback', (req, res, next) => {
-    console.log('\n🚀 OAUTH CALLBACK - ENHANCED HANDLER');
-    
-    passport.authenticate('google', { 
-      failureRedirect: '/api/auth/error',
-      session: true 
-    })(req, res, (err) => {
-      if (err) {
-        console.error('❌ OAuth authentication error:', err);
-        return res.redirect('/?error=oauth_failed');
-      }
-      
-      const user = req.user as any;
-      if (!user) {
-        console.error('❌ No user after OAuth');
-        return res.redirect('/?error=no_user');
-      }
-      
-      console.log('✅ OAuth successful for:', user.email);
-      console.log('Session ID:', req.sessionID);
-      
-      // Force session save
-      req.session.save((saveErr) => {
-        if (saveErr) {
-          console.error('❌ Session save error:', saveErr);
-          return res.redirect('/?error=session_save_failed');
-        }
-        
-        console.log('✅ Session saved successfully');
-        res.redirect('/?auth=success');
-      });
-    });
-  });
+  // 4. OAuth callback handler is registered in `routes.ts` to avoid
+  //    duplicate handlers causing conflicts. This placeholder is kept
+  //    for backward compatibility but no longer registers its own
+  //    callback route.
 
   // 5. Session recovery endpoint
   app.get('/api/auth/recover', (req, res) => {

--- a/server/oauth-completion-handler.ts
+++ b/server/oauth-completion-handler.ts
@@ -84,8 +84,12 @@ export async function handleOAuthCallback(req: Request, res: Response) {
       res.redirect('/?auth=success&test=failed');
     }
     
-  } catch (error) {
+  } catch (error: any) {
     console.error('❌ OAuth callback error:', error);
+    const errorDesc = error?.response?.data?.error;
+    if (errorDesc === 'invalid_grant') {
+      return res.redirect('/?error=invalid_grant');
+    }
     res.redirect('/?error=callback_failed');
   }
 }

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -227,7 +227,9 @@ export async function registerRoutes(app: Express): Promise<Server> {
 
   // Configure Google OAuth2 Strategy - Use current domain with deployment detection
   let baseURL;
-  if (process.env.REPLIT_DEV_DOMAIN) {
+  if (process.env.BASE_URL) {
+    baseURL = process.env.BASE_URL;
+  } else if (process.env.REPLIT_DEV_DOMAIN) {
     baseURL = `https://${process.env.REPLIT_DEV_DOMAIN}`;
   } else if (process.env.REPLIT_DOMAINS) {
     // Use the first domain from REPLIT_DOMAINS for deployment


### PR DESCRIPTION
## Summary
- document environment variables and project setup in README
- add `.env.example` template
- ignore local `.env` files
- improve base URL detection for OAuth
- avoid duplicate OAuth callback route
- handle `invalid_grant` errors during OAuth callback

## Testing
- `npm run check` *(fails: Module declaration names may only use quotes)*

------
https://chatgpt.com/codex/tasks/task_e_687582ef3f7c83278c1acac46661fb19